### PR TITLE
add support for inheriting methods from a base class

### DIFF
--- a/spec/basic_spec.cr
+++ b/spec/basic_spec.cr
@@ -157,4 +157,32 @@ describe TestOperationBasics do
     assert operation.log.to_s.gsub("\n", " ") == operation.log.to_s(one_line: true)
   end
 
+  class TestInheritingMethodsParent < Hathor::Operation
+    property counter = 0
+    
+    def some_step!
+      @counter += 1
+    end
+
+    def some_other_step!
+      @counter -= 10
+    end
+  end
+
+  class TestInheritingMethods < TestInheritingMethodsParent
+    step some_step!
+    step some_other_step!
+
+    def some_other_step!
+      @counter += 5
+    end
+  end
+
+  test "inherit methods of ancestor" do
+    operation = TestInheritingMethods.run
+    assert operation.success?
+    assert 6 == operation.counter
+    assert 3 == operation.log.entries.size
+  end
+
 end

--- a/src/hathor-operation.cr
+++ b/src/hathor-operation.cr
@@ -105,10 +105,9 @@ module Hathor
 
       def run
         {% if nil != CLASS_CONFIG[:context] %}
-          {% methods = @type.methods.map { |method| method.name.id } %}
           {% for step_index in (1..CLASS_CONFIG[:context][:step_count]) %}
             # raise if step calling an undefined method
-            {% if !methods.includes?(CLASS_CONFIG[step_index][:method]) %}
+            {% if !@type.has_method?(CLASS_CONFIG[step_index][:method]) %}
               {% raise "#{@type.id}: calling undefined method '#{CLASS_CONFIG[step_index][:method]}' in a #{CLASS_CONFIG[step_index][:step_type]} macro" %}
             {% end %}
 


### PR DESCRIPTION
Currently there is a check in place to prevent that undefined methods are called in steps. This check uses `TypeNode#methods`  (see [docs](https://crystal-lang.org/api/0.35.1/Crystal/Macros/TypeNode.html#methods:ArrayLiteral(Def)-instance-method)) that does not include inherited methods. However, `TypeNode#has_method?` (see [source](https://github.com/crystal-lang/crystal/blob/33670931a7ac56fa3e7b737957a9c6413605eb83/src/compiler/crystal/types.cr#L482)) seems to take inheritance into consideration.

I think this would be a great addition, because it restores the default crystal class behavior. Also it would allow for modules being used for step definitions which can be useful for stateless steps.

### Use Case

A simple usage example would be having a base class that defines some behaviour:

```crystal
class BaseOperation < Hathor::Operation
  property user : String

  def initialize(@user : String); end

  def authorized?
    user == "admin"
  end
end

class SomeAction < BaseOperation
  policy authorized?
  step authorized!
  failure unauthorized!

  def authorized!
    puts "Authorized!"
  end

  def unauthorized!
    puts "Unauthorized!"
  end
end

SomeAction.run(user: 'test')
# => "Unauthorized!"

SomeAction.run(user: 'admin')
# => "Authorized!"
``` 
