### PR TITLE
[BUGFIX] fix printing the OperationLogger to IO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+- fix `OperationLogger#to_s` to have an overload for `OperationLogger#to_s(io : IO)` (by @richardboehme)
+
 ### 0.3.0
 
 - add nested operation support by @richardboehme

--- a/src/operation_logger.cr
+++ b/src/operation_logger.cr
@@ -78,6 +78,10 @@ module Hathor
         out
       end
     end
+    
+    def to_s(io : IO)
+      io << to_s
+    end
 
   end
 end


### PR DESCRIPTION
Previously `puts operation.log` would print just an empty line. This is
because `puts` invokes `operation.log.to_s(STDOUT)` that needs to insert
contents into the STDOUT IO.

Now we just overload `to_s` so that if passed an IO object it will write
the operation log into it.